### PR TITLE
ensure compatibility with "sls deploy function ..."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2023-04-17
+
+### feat
+
+-   support deployment of a single function with "serverless deploy function -f functionName"
+
 ## [1.1.0] - 2022-11-15
 
 ### feat

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ class EsmLayer {
       'after:package:createDeploymentArtifacts': async () => {
         await this.packageFinalize();
       },
+      'after:deploy:function:packageFunction': async () => {
+        await this.packageFinalize();
+      }
     };
   }
 
@@ -76,7 +79,11 @@ class EsmLayer {
           follow: false
       }
     );
+    const onStreamFinished = new Promise((resolve) => {
+      output.on('finish', resolve);
+    });
     await archive.finalize();
+    await onStreamFinished;
   }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-esm-layer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A serverless plugin that will fix the problem of AWS-Layers not working with ES Modules (ESM .mjs)",
   "engines": {
     "node": ">=14.x"


### PR DESCRIPTION
- after:package:createDeploymentArtifacts  hooks are ot  called when "sls deploy function" is executed

- wait until stream is closed to ensure that all content is written to disk